### PR TITLE
BUGFIX: don't crash on exit (the document is nil momentarily)

### DIFF
--- a/xliff-tool/ViewController.swift
+++ b/xliff-tool/ViewController.swift
@@ -46,9 +46,7 @@ class ViewController: NSViewController, NSOutlineViewDataSource, NSOutlineViewDe
                 xliffFile = nil
             }
             outlineView.reloadData()
-            for item in xliffFile!.files {
-                outlineView?.expandItem(item)
-            }
+            xliffFile?.files.forEach { outlineView?.expandItem($0) }
         }
     }
     


### PR DESCRIPTION
Resolves #10. I think when you quit the document is momentarily nil, and there's no reason to expand items in that case, so just using optional chaining solves it.