### PR TITLE
BUGFIX: don't throw an exception when trying to save

### DIFF
--- a/xliff-tool/ViewController.swift
+++ b/xliff-tool/ViewController.swift
@@ -102,21 +102,20 @@ class ViewController: NSViewController, NSOutlineViewDataSource, NSOutlineViewDe
     }
     
     func updateTranslationForElement(_ elem: XMLElement, newValue: String) {
-        
         if elem.elements(forName: "target").count == 0 {
             elem.addChild(XMLElement(name: "target", stringValue: ""))
         }
-        
-        let target = elem.elements(forName: "target").first!
-        if newValue != target.stringValue {
-            // register undo/redo operation
-            (document?.undoManager?.prepare(withInvocationTarget: self) as AnyObject)
-                .updateTranslationForElement(elem, newValue: target.stringValue!)
-            
-            // update the value in place
-            target.stringValue = newValue
+        guard let target = elem.elements(forName: "target").first else { return print("Not able to find or create a `target` child element") }
+        guard newValue != target.stringValue else { return } // no need to update identical values
+      
+        // register undo/redo operation
+        if let undoTarget = document?.undoManager?.prepare(withInvocationTarget: self) {
+          (undoTarget as AnyObject)
+            .updateTranslationForElement(elem, newValue: target.stringValue!)
         }
-        
+      
+        // update the value in place
+        target.stringValue = newValue
     }
     
     private var filter = XliffFile.Filter()


### PR DESCRIPTION
Flattening out the nesting and removing some force-unwrapping by using some `guard` statements.

As far as I know there's no actual change in logic or behavior except that if it can't create the `undoManager` it won't try to set up the undo action.

I've never used the undo API before though so you'll probably want to double-check this one.

Also, it's super weird that you aren't able to repro this locally. More of an FYI PR then :)