### PR TITLE
support to copy multiple selected source translations to target

### DIFF
--- a/xliff-tool/Base.lproj/Main.storyboard
+++ b/xliff-tool/Base.lproj/Main.storyboard
@@ -281,7 +281,7 @@ CA
                                     <rect key="frame" x="1" y="0.0" width="841" height="479"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" headerView="Tl8-ug-pLb" viewBased="YES" indentationPerLevel="10" indentationMarkerFollowsCell="NO" autoresizesOutlineColumn="YES" outlineTableColumn="4VP-J9-NbX" id="Y8P-hs-l3X">
+                                        <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" autosaveColumns="NO" rowSizeStyle="automatic" headerView="Tl8-ug-pLb" viewBased="YES" indentationPerLevel="10" indentationMarkerFollowsCell="NO" autoresizesOutlineColumn="YES" outlineTableColumn="4VP-J9-NbX" id="Y8P-hs-l3X">
                                             <rect key="frame" x="0.0" y="0.0" width="841" height="456"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <size key="intercellSpacing" width="3" height="2"/>

--- a/xliff-tool/ViewController.swift
+++ b/xliff-tool/ViewController.swift
@@ -190,14 +190,16 @@ class ViewController: NSViewController, NSOutlineViewDataSource, NSOutlineViewDe
     
     /** Copy the source string to target for further editing. If no row is selected, this method does nothing */
     @IBAction func copySourceToTargetForSelectedRow(_ sender: AnyObject) {
-        if outlineView.selectedRow != -1,
-            let elem = outlineView.item(atRow: outlineView.selectedRow) as? XliffFile.TransUnit {
-            let newValue = elem.source
-            updateTranslation(for: elem, newValue: newValue )
-            outlineView.reloadData(forRowIndexes: IndexSet(integer: outlineView.selectedRow),
-                                   columnIndexes: IndexSet(integer: outlineView.column(
-                                    withIdentifier: "AutomaticTableColumnIdentifier.1")))
+      for (_,row) in outlineView.selectedRowIndexes.enumerated() {
+        if row != -1,
+          let elem = outlineView.item(atRow: row) as? XliffFile.TransUnit {
+          let newValue = elem.source
+          updateTranslation(for: elem, newValue: newValue )
         }
+      }
+      outlineView.reloadData(forRowIndexes: outlineView.selectedRowIndexes,
+                             columnIndexes: IndexSet(integer: outlineView.column(
+                              withIdentifier: "AutomaticTableColumnIdentifier.1")))
     }
     
     /** Activates the search/filter field in the UI so that the user can begin typing */


### PR DESCRIPTION
This enables multi-selection for rows and also extends the copy source to target action to use the complete selection not just the last selected row.