### PR TITLE
Dynamic Row Height magic removed

### DIFF
--- a/xliff-tool/Base.lproj/Main.storyboard
+++ b/xliff-tool/Base.lproj/Main.storyboard
@@ -195,7 +195,7 @@ CA
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="View" id="xhT-rW-p3X">
                                     <items>
-                                        <menuItem title="Compact Rows" state="on" keyEquivalent="H" id="yB5-Io-E88">
+                                        <menuItem title="Compact Rows" state="mixed" keyEquivalent="H" id="yB5-Io-E88">
                                             <connections>
                                                 <action selector="toggleCompactRowsMode:" target="Ady-hI-5gd" id="n5c-pf-OuA"/>
                                             </connections>
@@ -434,11 +434,11 @@ CA
                                         </outlineView>
                                     </subviews>
                                 </clipView>
-                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="Ft8-t6-lCk">
+                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="Ft8-t6-lCk">
                                     <rect key="frame" x="1" y="463" width="841" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
-                                <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="PdF-D3-22Q">
+                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="PdF-D3-22Q">
                                     <rect key="frame" x="224" y="17" width="15" height="102"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>

--- a/xliff-tool/ViewController.swift
+++ b/xliff-tool/ViewController.swift
@@ -8,13 +8,7 @@
 
 import Cocoa
 
-class ViewController: NSViewController, NSOutlineViewDataSource, NSOutlineViewDelegate {
-
-    private struct Configuration {
-        // max number of items in the XLIFF file to allow dynamic row height for all table rows
-        // else we will re-tile just the selected row after selection, the remaining cells remaining single lined
-        static let maxItemsForDynamicRowHeight = 150
-    }
+class ViewController: NSViewController, NSOutlineViewDataSource, NSOutlineViewDelegate, NSMenuItemValidation {
 
     // MARK: private data
     private var xliffFile: XliffFile? { didSet { reloadUI() } }
@@ -29,7 +23,7 @@ class ViewController: NSViewController, NSOutlineViewDataSource, NSOutlineViewDe
         return true
     }
     
-    private var dynamicRowHeight = false { didSet { outlineView?.reloadData() } }
+    private var dynamicRowHeight = true
     
     weak var document: Document? {
         didSet {
@@ -37,10 +31,6 @@ class ViewController: NSViewController, NSOutlineViewDataSource, NSOutlineViewDe
                 // already validated, this should never fail
                 try! xliffFile = XliffFile(xliffDocument: xliffDocument)
                 xliffFile!.filter = filter
-                
-                if let file = xliffFile, file.totalCount < Configuration.maxItemsForDynamicRowHeight {
-                    dynamicRowHeight = true
-                }
             } else {
                 xliffFile = nil
             }
@@ -162,6 +152,7 @@ class ViewController: NSViewController, NSOutlineViewDataSource, NSOutlineViewDe
         if let menuItem = sender as? NSMenuItem {
             menuItem.state = menuItem.state == .on ? .off : .on
             dynamicRowHeight = menuItem.state == .off
+            outlineView.reloadData()
         }
     }
     


### PR DESCRIPTION
don't set/unset the compact rows setting according to the number of items in the xliff file
This functionality was kind-of confusing for a lot of users anyway